### PR TITLE
version 1.5 to be merged in elpaso:master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 all: clean compile package localrepo
 
+install: copy2qgis
+
 compile:
 	pyuic4 -o Ui_QuickWKT.py Ui_QuickWKT.ui
 	pyrcc4 -o resources.py resources.qrc
@@ -16,6 +18,9 @@ package: clean
 
 localrepo:
 	cp ../QuickWKT.zip /home/ale/public_html/qgis/QuickWKT.zip
+
+copy2qgis: package
+	unzip -o ../QuickWKT.zip -d ~/.qgis/python/plugins
 
 check test:
 	@echo "Sorry: not implemented yet."

--- a/README
+++ b/README
@@ -1,0 +1,29 @@
+QuickWKT Qgis Plugin
+====================
+
+This Qgis Plugin makes it possible to show features in QGIS using WKT
+
+This plugin is supposed to be installed via the plugin manager of QGIS
+
+
+Code: https://github.com/elpaso/quickwkt
+
+Plugin: http://plugins.qgis.org/plugins/QuickWKT/
+
+
+Original Author: Alessandro Pasotti
+
+Contributing Autors: Richard Duivenvoorde
+
+Version 1.5
+-----------
+
+- add more then one feature in the txt area, also a set of more geometry types
+- create only layer type if needed: if you only paste a wkt of a point, then only a point layer is created
+- lines which cannot be parsed combine to a warning
+- user can either choose if the layers should be reused, OR on every use of plugin should create new layers
+
+Version 1.0
+-----------
+
+- Initial version

--- a/Ui_QuickWKT.py
+++ b/Ui_QuickWKT.py
@@ -2,42 +2,46 @@
 
 # Form implementation generated from reading ui file 'Ui_QuickWKT.ui'
 #
-# Created: Thu Oct 14 11:48:01 2010
-#      by: PyQt4 UI code generator 4.7.2
+# Created: Mon Nov 14 20:05:12 2011
+#      by: PyQt4 UI code generator 4.8.3
 #
 # WARNING! All changes made in this file will be lost!
 
 from PyQt4 import QtCore, QtGui
 
+try:
+    _fromUtf8 = QtCore.QString.fromUtf8
+except AttributeError:
+    _fromUtf8 = lambda s: s
+
 class Ui_QuickWKT(object):
     def setupUi(self, QuickWKT):
-        QuickWKT.setObjectName("QuickWKT")
-        QuickWKT.resize(513, 280)
-        self.verticalLayoutWidget = QtGui.QWidget(QuickWKT)
-        self.verticalLayoutWidget.setGeometry(QtCore.QRect(10, 10, 491, 241))
-        self.verticalLayoutWidget.setObjectName("verticalLayoutWidget")
-        self.verticalLayout = QtGui.QVBoxLayout(self.verticalLayoutWidget)
-        self.verticalLayout.setObjectName("verticalLayout")
-        self.addressLabel = QtGui.QLabel(self.verticalLayoutWidget)
-        self.addressLabel.setObjectName("addressLabel")
+        QuickWKT.setObjectName(_fromUtf8("QuickWKT"))
+        QuickWKT.resize(490, 306)
+        self.verticalLayout = QtGui.QVBoxLayout(QuickWKT)
+        self.verticalLayout.setObjectName(_fromUtf8("verticalLayout"))
+        self.addressLabel = QtGui.QLabel(QuickWKT)
+        self.addressLabel.setObjectName(_fromUtf8("addressLabel"))
         self.verticalLayout.addWidget(self.addressLabel)
-        self.wkt = QtGui.QPlainTextEdit(self.verticalLayoutWidget)
-        self.wkt.setObjectName("wkt")
+        self.wkt = QtGui.QPlainTextEdit(QuickWKT)
+        self.wkt.setObjectName(_fromUtf8("wkt"))
         self.verticalLayout.addWidget(self.wkt)
-        spacerItem = QtGui.QSpacerItem(20, 40, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
-        self.verticalLayout.addItem(spacerItem)
-        self.buttonBox = QtGui.QDialogButtonBox(self.verticalLayoutWidget)
+        self.cbxnewlayer = QtGui.QCheckBox(QuickWKT)
+        self.cbxnewlayer.setObjectName(_fromUtf8("cbxnewlayer"))
+        self.verticalLayout.addWidget(self.cbxnewlayer)
+        self.buttonBox = QtGui.QDialogButtonBox(QuickWKT)
         self.buttonBox.setOrientation(QtCore.Qt.Horizontal)
         self.buttonBox.setStandardButtons(QtGui.QDialogButtonBox.Cancel|QtGui.QDialogButtonBox.Ok)
-        self.buttonBox.setObjectName("buttonBox")
+        self.buttonBox.setObjectName(_fromUtf8("buttonBox"))
         self.verticalLayout.addWidget(self.buttonBox)
 
         self.retranslateUi(QuickWKT)
-        QtCore.QObject.connect(self.buttonBox, QtCore.SIGNAL("accepted()"), QuickWKT.accept)
-        QtCore.QObject.connect(self.buttonBox, QtCore.SIGNAL("rejected()"), QuickWKT.reject)
+        QtCore.QObject.connect(self.buttonBox, QtCore.SIGNAL(_fromUtf8("accepted()")), QuickWKT.accept)
+        QtCore.QObject.connect(self.buttonBox, QtCore.SIGNAL(_fromUtf8("rejected()")), QuickWKT.reject)
         QtCore.QMetaObject.connectSlotsByName(QuickWKT)
 
     def retranslateUi(self, QuickWKT):
         QuickWKT.setWindowTitle(QtGui.QApplication.translate("QuickWKT", "QuickWKT", None, QtGui.QApplication.UnicodeUTF8))
         self.addressLabel.setText(QtGui.QApplication.translate("QuickWKT", "Enter WKT:", None, QtGui.QApplication.UnicodeUTF8))
+        self.cbxnewlayer.setText(QtGui.QApplication.translate("QuickWKT", "Create new layer for every geometry type", None, QtGui.QApplication.UnicodeUTF8))
 

--- a/Ui_QuickWKT.ui
+++ b/Ui_QuickWKT.ui
@@ -6,58 +6,42 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>513</width>
-    <height>280</height>
+    <width>490</width>
+    <height>306</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>QuickWKT</string>
   </property>
-  <widget class="QWidget" name="verticalLayoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>10</y>
-     <width>491</width>
-     <height>241</height>
-    </rect>
-   </property>
-   <layout class="QVBoxLayout" name="verticalLayout">
-    <item>
-     <widget class="QLabel" name="addressLabel">
-      <property name="text">
-       <string>Enter WKT:</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QPlainTextEdit" name="wkt"/>
-    </item>
-    <item>
-     <spacer name="verticalSpacer">
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
-      </property>
-      <property name="sizeHint" stdset="0">
-       <size>
-        <width>20</width>
-        <height>40</height>
-       </size>
-      </property>
-     </spacer>
-    </item>
-    <item>
-     <widget class="QDialogButtonBox" name="buttonBox">
-      <property name="orientation">
-       <enum>Qt::Horizontal</enum>
-      </property>
-      <property name="standardButtons">
-       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="addressLabel">
+     <property name="text">
+      <string>Enter WKT:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPlainTextEdit" name="wkt"/>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="cbxnewlayer">
+     <property name="text">
+      <string>Create new layer for every geometry type</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections>

--- a/__init__.py
+++ b/__init__.py
@@ -25,7 +25,7 @@ def description():
 def version():
   return "Version 1.0"
 def qgisMinimumVersion():
-  return "1.0"
+  return "1.5"
 def classFactory(iface):
   # load GeoCoding class from file GeoCoding
   from QuickWKT import QuickWKT

--- a/resources.py
+++ b/resources.py
@@ -2,8 +2,8 @@
 
 # Resource object code
 #
-# Created: gio ott 14 11:48:01 2010
-#      by: The Resource Compiler for PyQt (Qt v4.6.2)
+# Created: Mon Nov 14 20:05:12 2011
+#      by: The Resource Compiler for PyQt (Qt v4.7.2)
 #
 # WARNING! All changes made in this file will be lost!
 


### PR DESCRIPTION
- add more then one feature in the txt area, also a set of more geometry types
- create only layer type if needed: if you only paste a wkt of a point, then only a point layer is created
- lines which cannot be parsed combine to a warning
- user can either choose if the layers should be reused, OR on every use of plugin should create new layers
- addition of README
