### PR TITLE
Use addMapLayers instead of addMapLayer, deprecated by qgis 1.9

### DIFF
--- a/QuickWKT.py
+++ b/QuickWKT.py
@@ -104,7 +104,7 @@ class QuickWKT:
         layer.setCrs(crs)
         # add attribute id, purely to make the features selectable from within attribute table
         layer.dataProvider().addAttributes([QgsField("name", QVariant.String)])
-        QgsMapLayerRegistry.instance().addMapLayer(layer)
+        QgsMapLayerRegistry.instance().addMapLayers([layer])
         return layer
 
     def parseGeometryCollection(self, wkt):


### PR DESCRIPTION
The change was tested against QGIS 1.8.0 and master.
Don't have a 1.7 around to try it, but should work there too...

Superceeds #10
