### PR TITLE
Better support for multiline WKT

### DIFF
--- a/QuickWKT.py
+++ b/QuickWKT.py
@@ -174,7 +174,8 @@ class QuickWKT:
         errors = ""
         regex = re.compile("([a-zA-Z]+)[\s]*(.*)")
         # Clean newlines where there is not a new object
-        wkt = wkt.replace(",\n", ",")
+        wkt = re.sub('\n *(?![PLMC])', ' ', wkt)
+        qDebug("wkt: " + wkt);
         # check all lines in text and try to make geometry of it, collecting errors and features
         for wktLine in wkt.split('\n'):
             try:


### PR DESCRIPTION
In particular fixes support for newline between ordinate values,
like: http://trac.osgeo.org/geos/ticket/580
With this commit you can copy&paste the whole preformatted block
to get two nice layers with those two geometries.

PS: I noticed there's no 2.0 compatible release yet in the plugin repository
