### PR TITLE
fix wkt with empty geometry

### DIFF
--- a/QuickWKT.py
+++ b/QuickWKT.py
@@ -91,7 +91,7 @@ class QuickWKT(object):
             text = str(self.dlg.wkt.toPlainText())
             layerTitle = self.dlg.layerTitle.text() or 'QuickWKT'
             try:
-                if "(" in text:
+                if any(st in text for st in ["(", "EMPTY"]):
                     self.save_wkt(text, layerTitle)
                 else:
                     self.save_wkb(text, layerTitle)
@@ -213,7 +213,7 @@ class QuickWKT(object):
         typeMap = {0: "Point", 1: "LineString", 2: "Polygon"}
         newFeatures = {}
         errors = ""
-        regex = re.compile("([a-zA-Z]+)[\s]*(.*)")
+        regex = re.compile("([a-zA-Z]+)[\s]*(.*)|EMPTY")
         # Clean newlines where there is not a new object
         wkt = re.sub('\n *(?![SPLMC])', ' ', wkt)
         qDebug("wkt: " + wkt)
@@ -239,7 +239,7 @@ class QuickWKT(object):
                         continue
 
                     geom = QgsGeometry.fromWkt(wktLine)
-                    if not geom:
+                    if not geom and not geom.isEmpty():
                         errors += ('-    "' + wktLine + '" is invalid\n')
                         continue
 

--- a/QuickWKT.py
+++ b/QuickWKT.py
@@ -88,7 +88,7 @@ class QuickWKT(object):
         result = self.dlg.exec_()
         # See if OK was pressed
         if result == 1 and self.dlg.wkt.toPlainText():
-            text = str(self.dlg.wkt.toPlainText())
+            text = str(self.dlg.wkt.toPlainText().upper())
             layerTitle = self.dlg.layerTitle.text() or 'QuickWKT'
             try:
                 if any(st in text for st in ["(", "EMPTY"]):
@@ -222,7 +222,7 @@ class QuickWKT(object):
             wktLine = wktLine.strip()
             if wktLine:
                 try:
-                    wktLine = wktLine.upper().replace("LINEARRING", "LINESTRING")
+                    wktLine = wktLine.replace("LINEARRING", "LINESTRING")
                     results = re.match(regex, wktLine)
                     wktLine = results.group(1) + " " + results.group(2)
                     qDebug("Attempting to save '%s'" % wktLine)


### PR DESCRIPTION
Hi,

First of all, thank you very much for this plugin that I use almost every day. I never took the time to tell you about it so I'm enjoying it. :blush: 

This PR proposes to fix a problem for WKT with empty geometry. If you try to insert a "point empty" wkt string, the plugin will return this message:
"There was an error with the service:
Non-hexadecimal digit found"

Because it uses the wkb method.

The fix consists to match "EMPTY" to parse it with wkt method.

A special note about line 242, in pyqgis for any empty geometry, python will return True for `not geom` so we also have to check that it is not an empty geometry with the dedicated method.

```python
ret = QgsGeometry().fromWkt('point empty') # or any geometry type
print(not ret)
# True
```