### PR TITLE
Allow NOT accumulating entries on a QuickWKT layer

### DIFF
--- a/QuickWKT.py
+++ b/QuickWKT.py
@@ -88,6 +88,7 @@ class QuickWKT(object):
         result = self.dlg.exec_()
         # See if OK was pressed
         if result == 1 and self.dlg.wkt.toPlainText():
+            self.new_layer_created = False
             text = str(self.dlg.wkt.toPlainText())
             layerTitle = self.dlg.layerTitle.text() or 'QuickWKT'
             try:
@@ -263,6 +264,10 @@ class QuickWKT(object):
         for typ in list(newFeatures.keys()):
             for f in newFeatures.get(typ):
                 layer = self.createLayer(typeMap[typ], layerTitle , f[1])
+                if self.dlg.cbxcleandata.isChecked() and not self.new_layer_created:
+                    self.new_layer_created = True
+                    layer.dataProvider().truncate()
+
                 layer.dataProvider().addFeatures([f[0]])
                 layer.updateExtents()
                 layer.reload()

--- a/Ui_QuickWKT.ui
+++ b/Ui_QuickWKT.ui
@@ -80,6 +80,13 @@
            </property>
           </spacer>
          </item>
+         <item>
+          <widget class="QCheckBox" name="cbxcleandata">
+           <property name="text">
+            <string>Start with an empty layer</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>


### PR DESCRIPTION
I've added a new checkbox to avoid accumulating polygons. When you enter a polygon, you'll get a layer with just that polygon, the previous ones you entered removed.

![imagen](https://user-images.githubusercontent.com/60652318/156570027-941bc988-f3a3-4db9-968a-ef7ec4e19b54.png)

